### PR TITLE
Fix two issues in linear tree-based model:

### DIFF
--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -164,10 +164,10 @@ def train_tree(
 
     def visit(node):
         if node.is_root:
-            relevant_instances = y[:, node.label_map].getnnz(axis=1) >= 0
+            _train_node(y, x, options, node)
         else:
             relevant_instances = y[:, node.label_map].getnnz(axis=1) > 0
-        _train_node(y[relevant_instances], x[relevant_instances], options, node)
+            _train_node(y[relevant_instances], x[relevant_instances], options, node)
         pbar.update()
 
     root.dfs(visit)


### PR DESCRIPTION
1. We should not filter any data instance in the root. (In the original code, we do not include the instances with zero label in the training.)

2. The outputs of a tree-based model should be in the range [0, 1]^{# of label}, which is corresponding to the probability estimates. Moreover, if we want to use sparse matrix to store the prediction values of a tree model, the value ``-inf'' will be a trouble issue. (This one is fixed by PR #2)

## What does this PR do?

add data rule for root in tree-based model

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.