### PR TITLE
Avoid additional memory usage when performing hstack.

### DIFF
--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -284,7 +284,7 @@ def _flatten_model(root: Node) -> tuple[linear.FlatModel, np.ndarray]:
 
     model = linear.FlatModel(
         name="flattened-tree",
-        weights=sparse.hstack(weights, "csr"),
+        weights=sparse.hstack(weights, "csc"),
         bias=bias,
         thresholds=0,
         multiclass=False,


### PR DESCRIPTION
## What does this PR do?
This PR optimizes memory usage during the `hstack` when stacking nodes saved in the CSC format. Previously, the output format was required to be in CSR format to ensure faster prediction times. However, this did not align with `hstack` fast path cases (i.e., the input and output format should be consistent), leading to approximately 2 times the model size in additional memory. This was caused by the intermediate conversion:
1. The nodes was first converted to a COO sparse matrix.
2. The COO matrix was then converted to CSR format.

However, if the output format is required to be in CSC format, the above intermediate conversion becomes unnecessary. In this case, the `hstack` operation can directly convert nodes to a CSC sparse matrix.

This PR addresses these inefficiencies and reduces the memory overhead by outputting a CSC sparse matrix during the stacking process.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.