### PR TITLE
Fix bugs in latest version of NumPy 

### DIFF
--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -95,7 +95,7 @@ class TreeModel:
                     continue
                 slice = np.s_[self.weight_map[node.index] : self.weight_map[node.index + 1]]
                 pred = instance_preds[slice]
-                children_score = score - np.square( np.maximum(0, 1 - pred) )
+                children_score = score - np.square(np.maximum(0, 1 - pred))
                 next_level.extend(zip(node.children, children_score.tolist()))
 
             cur_level = sorted(next_level, key=lambda pair: -pair[1])[:beam_width]
@@ -106,7 +106,7 @@ class TreeModel:
         for node, score in cur_level:
             slice = np.s_[self.weight_map[node.index] : self.weight_map[node.index + 1]]
             pred = instance_preds[slice]
-            scores[node.label_map] = np.exp( score - np.square( np.maximum(0, 1 - pred) ) )
+            scores[node.label_map] = np.exp(score - np.square(np.maximum(0, 1 - pred)))
         return scores
 
 
@@ -151,14 +151,14 @@ def train_tree(
     root.dfs(count)
 
     model_size = get_estimated_model_size(root)
-    print(f'The estimated tree model size is: {model_size / (1024**3):.3f} GB')
+    print(f"The estimated tree model size is: {model_size / (1024**3):.3f} GB")
 
     # Calculate the total memory (excluding swap) on the local machine
-    total_memory = psutil.virtual_memory().total 
-    print(f'Your system memory is: {total_memory / (1024**3):.3f} GB')
+    total_memory = psutil.virtual_memory().total
+    print(f"Your system memory is: {total_memory / (1024**3):.3f} GB")
 
-    if (total_memory <= model_size):
-        raise MemoryError(f'Not enough memory to train the model.')
+    if total_memory <= model_size:
+        raise MemoryError(f"Not enough memory to train the model.")
 
     pbar = tqdm(total=num_nodes, disable=not verbose)
 
@@ -221,7 +221,7 @@ def get_estimated_model_size(root):
 
     def collect_stat(node: Node):
         nonlocal total_num_weights
-        
+
         if node.isLeaf():
             total_num_weights += len(node.label_map) * node.num_features_used
         else:
@@ -231,7 +231,7 @@ def get_estimated_model_size(root):
 
     # 16 is because when storing sparse matrices, indices (int64) require 8 bytes and floats require 8 bytes
     # Our study showed that among the used features of every binary classification problem, on average no more than 2/3 of weights obtained by the dual coordinate descent method are non-zeros.
-    return total_num_weights * 16 * 2/3
+    return total_num_weights * 16 * 2 / 3
 
 
 def _train_node(y: sparse.csr_matrix, x: sparse.csr_matrix, options: str, node: Node):

--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -95,18 +95,18 @@ class TreeModel:
                     continue
                 slice = np.s_[self.weight_map[node.index] : self.weight_map[node.index + 1]]
                 pred = instance_preds[slice]
-                children_score = score - np.maximum(0, 1 - pred) ** 2
+                children_score = score - np.square( np.maximum(0, 1 - pred) )
                 next_level.extend(zip(node.children, children_score.tolist()))
 
             cur_level = sorted(next_level, key=lambda pair: -pair[1])[:beam_width]
             next_level = []
 
         num_labels = len(self.root.label_map)
-        scores = np.full(num_labels, 0)
+        scores = np.full(num_labels, 0.0)
         for node, score in cur_level:
             slice = np.s_[self.weight_map[node.index] : self.weight_map[node.index + 1]]
             pred = instance_preds[slice]
-            scores[node.label_map] = np.exp(score - np.maximum(0, 1 - pred) ** 2)
+            scores[node.label_map] = np.exp( score - np.square( np.maximum(0, 1 - pred) ) )
         return scores
 
 


### PR DESCRIPTION

Fix bugs in using latest version of NumPy for tree-based model.

1. np.full(..., 0) returns an np.array with int64, but we need float64.
2. np.matrix ** 2 will be represented as the square of a ``square matrix'' in the latest NumPy version. 
    For the element-wise square of an np.matrix, we should use np.square( np.matrix ).


## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.