### PR TITLE
[Hotfix] Set scipy version to < 1.14.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numba
 pandas>1.3.0
 PyYAML
 scikit-learn
-scipy==1.13.1
+scipy<=1.13.1
 tqdm
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numba
 pandas>1.3.0
 PyYAML
 scikit-learn
-scipy
+scipy==1.13.1
 tqdm
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numba
 pandas>1.3.0
 PyYAML
 scikit-learn
-scipy<=1.13.1
+scipy<1.14.0
 tqdm
 psutil

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.7.1
+version = 0.7.2
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE
@@ -30,7 +30,7 @@ install_requires =
     pandas>1.3.0
     PyYAML
     scikit-learn
-    scipy
+    scipy==1.13.1
     tqdm
 
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pandas>1.3.0
     PyYAML
     scikit-learn
-    scipy<=1.13.1
+    scipy<1.14.0
     tqdm
 
 python_requires = >=3.8

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pandas>1.3.0
     PyYAML
     scikit-learn
-    scipy==1.13.1
+    scipy<=1.13.1
     tqdm
 
 python_requires = >=3.8


### PR DESCRIPTION
## What does this PR do?

- Set scipy version to <1.14.0
- Recently released SciPy 1.14.0+ ([release note](https://github.com/scipy/scipy/releases/tag/v1.14.0)) includes updates to `scipy.sparse`, such as the removal of deprecated functions (e.g., [scipy.sparse.csr_matrix.A](https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.sparse.csr_matrix.A.html)), which cause errors in linear code. For example,
https://github.com/ntumlgroup/LibMultiLabel/blob/3d40d144e22b40aa29625caf8bff393aa05fb035/libmultilabel/linear/linear.py#L72
- Note for default dependencies
  |     Python   |       scipy      |      numpy      |                      |
  |-----------:|-------------:|-------------:|-------------:|
  |       3.8        |      1.10.1        |      1.24.4       |     autotest   |
  |       3.10      |      **1.14.1** (error) |      2.0.2         |   set scipy to <1.14.0 in this PR |   



## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.