### PR TITLE
Fix the issue where primal solver cannot be used in libmultilabel.

### DIFF
--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -5,7 +5,7 @@ import os
 
 import numpy as np
 import scipy.sparse as sparse
-from liblinear.liblinearutil import train, problem, parameter, L2R_L2LOSS_SVC_DUAL, L2R_L1LOSS_SVC_DUAL
+from liblinear.liblinearutil import train, problem, parameter, solver_names
 from tqdm import tqdm
 
 __all__ = [
@@ -335,7 +335,7 @@ def _do_train(y: np.ndarray, x: sparse.csr_matrix, options: str) -> np.matrix:
 
     prob = problem(y, x)
     param = parameter(options)
-    if param.solver_type in [L2R_L1LOSS_SVC_DUAL, L2R_L2LOSS_SVC_DUAL]:
+    if param.solver_type in [solver_names.L2R_L1LOSS_SVC_DUAL, solver_names.L2R_L2LOSS_SVC_DUAL]:
         param.w_recalc = True   # only works for solving L1/L2-SVM dual
     with silent_stderr():
         model = train(prob, param)
@@ -598,7 +598,8 @@ def train_binary_and_multiclass(
 
     prob = problem(y, x)
     param = parameter(options)
-    param.w_recalc = True
+    if param.solver_type in [solver_names.L2R_L1LOSS_SVC_DUAL, solver_names.L2R_L2LOSS_SVC_DUAL]:
+        param.w_recalc = True
     with silent_stderr():
         model = train(prob, param)
 

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -336,7 +336,7 @@ def _do_train(y: np.ndarray, x: sparse.csr_matrix, options: str) -> np.matrix:
     prob = problem(y, x)
     param = parameter(options)
     if param.solver_type in [solver_names.L2R_L1LOSS_SVC_DUAL, solver_names.L2R_L2LOSS_SVC_DUAL]:
-        param.w_recalc = True   # only works for solving L1/L2-SVM dual
+        param.w_recalc = True  # only works for solving L1/L2-SVM dual
     with silent_stderr():
         model = train(prob, param)
 

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -5,7 +5,7 @@ import os
 
 import numpy as np
 import scipy.sparse as sparse
-from liblinear.liblinearutil import train, problem, parameter
+from liblinear.liblinearutil import train, problem, parameter, L2R_L2LOSS_SVC_DUAL, L2R_L1LOSS_SVC_DUAL
 from tqdm import tqdm
 
 __all__ = [
@@ -335,7 +335,8 @@ def _do_train(y: np.ndarray, x: sparse.csr_matrix, options: str) -> np.matrix:
 
     prob = problem(y, x)
     param = parameter(options)
-    param.w_recalc = True   # only works for solving L1/L2-SVM dual
+    if param.solver_type in [L2R_L1LOSS_SVC_DUAL, L2R_L2LOSS_SVC_DUAL]:
+        param.w_recalc = True   # only works for solving L1/L2-SVM dual
     with silent_stderr():
         model = train(prob, param)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-liblinear-multicore
+liblinear-multicore>=2.49.0
 numba
 pandas>1.3.0
 PyYAML

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.7.2
+version = 0.7.3
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE
@@ -25,7 +25,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    liblinear-multicore
+    liblinear-multicore>=2.49.0
     numba
     pandas>1.3.0
     PyYAML


### PR DESCRIPTION
## What does this PR do?
Because the weight recalculation technique only applies to the L1/L2-SVM dual solver in LIBLINEAR, LIBLINEAR prohibits use of the other solvers when the `w_recalc` flag is set. However, LibMultiLabel always sets the `w_recalc` flag despite using  the other solvers. To fix this issue, the `w_recalc` flag is now set only when using L1/L2-SVM dual solver. 

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.