### PR TITLE
Add psutil dependency to install requires

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.7.3
+version = 0.7.4
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE
@@ -32,6 +32,7 @@ install_requires =
     scikit-learn
     scipy<1.14.0
     tqdm
+    psutil
 
 python_requires = >=3.8
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes a missing dependency bug by adding `psutil` to the install requirements.

Users encountered import errors when installing the library via `pip install` becuase:
* `psutil` was not declared as a dependency in `setup.cfg`
* This caused `ImportError: No module named 'psutil'` when using the library
 
## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.