### PR TITLE
Upgrade minimum python version from 3.8 to 3.10

### DIFF
--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8"]
+        python-version: ["3.10"]
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.8'
+        python-version: '3.10'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LibMultiLabel is a library for binary, multi-class, and multi-label classificati
 This is an on-going development so many improvements are still being made. Comments are very welcome.
 
 ## Environments
-- Python: 3.8+
+- Python: 3.10+
 - CUDA: 11.8, 12.1 (if training neural networks by GPU)
 - Pytorch: 2.0.1+
 

--- a/docs/cli/nn.rst
+++ b/docs/cli/nn.rst
@@ -133,7 +133,8 @@ To deploy/evaluate a model (i.e., a pre-obtained checkpoint), you can predict a 
 Hyper-parameter Search
 ^^^^^^^^^^^^^^^^^^^^^^
 
-Parameter selection is known to be extremely important in machine learning practice; see a powerful reminder in "`this paper <https://www.csie.ntu.edu.tw/~cjlin/papers/parameter_selection/acl2021_parameter_selection.pdf>`_". Here we leverage `Ray Tune <https://docs.ray.io/en/master/tune/index.html>`__, which is a python library for hyper-parameter tuning, to select parameters. Due to the dependency of Ray Tune, first make sure your python version is not greater than 3.8. Then, install the related packages with::
+Parameter selection is known to be extremely important in machine learning practice; see a powerful reminder in "`this paper <https://www.csie.ntu.edu.tw/~cjlin/papers/parameter_selection/acl2021_parameter_selection.pdf>`_". 
+Here we leverage `Ray Tune <https://docs.ray.io/en/master/tune/index.html>`__, which is a python library for hyper-parameter tuning, to select parameters. Install the related packages with::
 
     pip3 install -Ur requirements_parameter_search.txt
 

--- a/docs/cli/ov_data_format.rst
+++ b/docs/cli/ov_data_format.rst
@@ -24,7 +24,7 @@ Install LibMultiLabel from Source
 
 * Environment
 
-    * Python: 3.8+
+    * Python: 3.10+
     * CUDA: 11.8, 12.1 (if training neural networks by GPU)
     * Pytorch 2.0.1+
 
@@ -37,7 +37,7 @@ and then create a virtual enviroment as follows.
 
 .. code-block:: bash
 
-    conda create -n LibMultiLabel python=3.8
+    conda create -n LibMultiLabel python=3.10
     conda activate LibMultiLabel
 
 * Clone `LibMultiLabel <https://github.com/ntumlgroup/LibMultiLabel>`_.

--- a/docs/readme
+++ b/docs/readme
@@ -1,4 +1,4 @@
-To build the documentation, please set up Python 3.8 and:
+To build the documentation, please set up Python 3.10 and:
     pip install -r ../requirements.txt
     pip install -r ../requirements_nn.txt
     pip install -r requirements.txt

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -27,7 +27,7 @@ class FlatModel:
     def __init__(
         self,
         name: str,
-        weights: np.matrix,
+        weights: np.matrix | sparse.csr_matrix,
         bias: float,
         thresholds: float | np.ndarray,
         multiclass: bool,
@@ -69,7 +69,21 @@ class FlatModel:
                 "csr",
             )
 
-        return (x * self.weights).A + self.thresholds
+        return self._to_dense_array(x * self.weights) + self.thresholds
+
+    def _to_dense_array(self, matrix: np.matrix | sparse.csr_matrix) -> np.ndarray:
+        """Convert a numpy or scipy matrix to a dense ndarray.
+
+        Args:
+            matrix (np.matrix | sparse.csr_matrix): A numpy or scipy sparse matrix.
+
+        Returns:
+            np.ndarray: A dense ndarray of `matrix`.
+        """
+        if sparse.issparse(matrix):
+            return matrix.toarray()
+        elif isinstance(matrix, np.matrix):
+            return matrix.A
 
 
 def train_1vsrest(

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -83,7 +83,7 @@ class FlatModel:
         if sparse.issparse(matrix):
             return matrix.toarray()
         elif isinstance(matrix, np.matrix):
-            return matrix.A
+            return np.asarray(matrix)
 
 
 def train_1vsrest(

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -458,7 +458,7 @@ def _cost_sensitive_one_label(y: np.ndarray, x: sparse.csr_matrix, options: str)
 
     param_space = [1, 1.33, 1.8, 2.5, 3.67, 6, 13]
 
-    bestScore = -np.Inf
+    bestScore = -np.inf
     for a in param_space:
         cv_options = f"{options} -w1 {a}"
         pred = _cross_validate(y, x, cv_options, perm)
@@ -532,7 +532,7 @@ def train_cost_sensitive_micro(
     l = y.shape[0]
     perm = np.random.permutation(l)
     param_space = [1, 1.33, 1.8, 2.5, 3.67, 6, 13]
-    bestScore = -np.Inf
+    bestScore = -np.inf
 
     if verbose:
         logging.info(f"Training cost-sensitive model for Micro-F1 on {num_class} labels")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ numba
 pandas>1.3.0
 PyYAML
 scikit-learn
-scipy<1.14.0
+scipy
 tqdm
 psutil

--- a/requirements_nn.txt
+++ b/requirements_nn.txt
@@ -1,6 +1,5 @@
 nltk
-# wait for https://github.com/Lightning-AI/pytorch-lightning/pull/19191
-lightning==2.0.9
+lightning
 # https://github.com/pytorch/text/releases
 torch<=2.3
 torchmetrics==0.10.3

--- a/requirements_nn.txt
+++ b/requirements_nn.txt
@@ -4,4 +4,5 @@ lightning
 torch<=2.3
 torchmetrics==0.10.3
 torchtext
-transformers
+# https://github.com/huggingface/transformers/issues/38464
+transformers<=4.51.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ install_requires =
     pandas>1.3.0
     PyYAML
     scikit-learn
-    scipy<1.14.0
+    scipy
     tqdm
     psutil
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,7 +43,7 @@ nn =
     torch<=2.3
     torchmetrics==0.10.3
     torchtext
-    transformers
+    transformers<=4.51.3
 
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.7.4
+version = 0.8.0
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE
@@ -20,7 +20,7 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.10
 
 [options]
 packages = find:
@@ -34,11 +34,11 @@ install_requires =
     tqdm
     psutil
 
-python_requires = >=3.8
+python_requires = >=3.10
 
 [options.extras_require]
 nn =
-    lightning==2.0.9
+    lightning
     nltk
     torch<=2.3
     torchmetrics==0.10.3


### PR DESCRIPTION
## What does this PR do?
Upgrade minimum python version from 3.8 to 3.10 (related PR: #19). Code changes includes:

- **System files and documents**: as files changed
- **Dependencies**
     - **lightning**: The ckpt issue (see https://github.com/Lightning-AI/pytorch-lightning/pull/19191 and https://github.com/Lightning-AI/pytorch-lightning/issues/19189)) has been solved, so there's no need to fix the version to 2.0.9.
     - **numpy**: `np.Inf` is deprecated (see [numpy 2.0.0 release note](https://numpy.org/devdocs/release/2.0.0-notes.html)).
     - **scipy**: `scipy.sparse.csr_matrix.A` is deprecated since 1.11.0 (see [sparse.csr_matrix.A](https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.sparse.csr_matrix.A.html)).
     - **transformers/torch CVE**:  `transformers` should load files with safetensors (see https://github.com/huggingface/transformers/issues/38464), set version to <=4.51.3.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [x] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.