### PR TITLE
Fix the bug in pruning tree predictions.

### DIFF
--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -101,7 +101,7 @@ class TreeModel:
         self.subtree_models = []
         for i in range(len(self.root.children)):
             subtree_weights_start = self.node_ptr[self.root.children[i].index]
-            subtree_weights_end = self.node_ptr[self.root.children[i+1].index] if i+1 < len(self.root.children) else -1
+            subtree_weights_end = self.node_ptr[self.root.children[i+1].index] if i+1 < len(self.root.children) else self.node_ptr[-1]
             slice = np.s_[:, subtree_weights_start:subtree_weights_end]
             subtree_flatmodel = linear.FlatModel(
                 name="subtree-flattened-tree",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.8.1
+version = 0.8.0
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.8.0
+version = 0.8.1
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE


### PR DESCRIPTION
## What does this PR do?

Fix the bug in PR #11. 
* **Bug:** The last classifier in the rightmost node of tree models was not included in the `subtree_weights`.
The original implementation

```python
subtree_weights_end = self.node_ptr[self.root.children[i+1].index] if i+1 < len(self.root.children) else -1
slice = np.s_[:, subtree_weights_start:subtree_weights_end]
```
causes incorrect slicing for the last subtree, leading to last classifiers in rightmost node(i.e., the last classifier in the last `subtree_weights` ) being excluded.
* **Solution:**  Use`self.node_ptr[-1]` to correctly include the last classifier. 

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.