### PR TITLE
Enable bias by default for linear models

### DIFF
--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -258,11 +258,13 @@ def _prepare_options(x: sparse.csr_matrix, options: str) -> tuple[sparse.csr_mat
         # workaround for liblinear warning about unspecified solver
         options_split.extend(["-s", "1"])
 
-    bias = -1.0
+    bias = 1.0
     if "-B" in options_split:
         i = options_split.index("-B")
         bias = float(options_split[i + 1])
         options_split = options_split[:i] + options_split[i + 2 :]
+
+    if bias > 0:
         x = sparse.hstack(
             [
                 x,


### PR DESCRIPTION
## Summary

- Use `1.0` as the default bias when `-B` is omitted.
- Add the bias feature column after resolving the effective bias value.
- Preserve `-B -1` as an explicit way to disable the bias term.

## Motivation

The previous default of `-1.0` disabled the bias term when users did not provide `-B`. Simply changing the default value was insufficient because the bias feature column was only added inside the explicit `-B` branch. Moving that check after option parsing makes the default behavior equivalent to passing `-B 1` while preserving existing explicit settings.

## Validation

- `python -m black --check libmultilabel/linear/linear.py`
- Ran a local smoke test covering default, explicit, and disabled bias settings, including one-vs-rest training and prediction.
