### PR TITLE
Enable bias by default for linear models

### DIFF
--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -258,11 +258,13 @@ def _prepare_options(x: sparse.csr_matrix, options: str) -> tuple[sparse.csr_mat
         # workaround for liblinear warning about unspecified solver
         options_split.extend(["-s", "1"])
 
-    bias = -1.0
+    bias = 1.0
     if "-B" in options_split:
         i = options_split.index("-B")
         bias = float(options_split[i + 1])
         options_split = options_split[:i] + options_split[i + 2 :]
+
+    if bias > 0:
         x = sparse.hstack(
             [
                 x,


### PR DESCRIPTION
## What does this PR do?

This PR enables bias by default for linear models. When `-B` is omitted,
the default bias is now `1.0`, making the behavior equivalent to passing
`-B 1`.

The effective bias value is resolved before deciding whether to append
the bias feature column. Positive `-B` values continue to override the
default, and `-B -1` can still be used to disable the bias term.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - All tests finished (13/13) on autotest/local-run. See test_report.txt for details.
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document.
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.

Not applicable; this PR does not modify quickstarts, tutorials, or documented APIs.